### PR TITLE
feat(agent): Wave 3 — Agent Intelligence (Ollama + ResponsePolicySection)

### DIFF
--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -1,3 +1,4 @@
+pub mod response_policy;
 pub mod thread_state;
 
 use std::collections::HashMap;

--- a/src/modes/response_policy.rs
+++ b/src/modes/response_policy.rs
@@ -1,0 +1,89 @@
+use crate::agent::prompt::{PromptContext, PromptSection};
+
+/// Injects a `## Response Policy` section into the system prompt.
+///
+/// Controls when the agent responds vs. stays silent, and what tone/style to use.
+/// Designed for use with `SystemPromptBuilder::add_section()` in Agent-based mode
+/// pipelines. The channel pipeline (W2) pre-builds mode system prompts and inlines
+/// the policy text directly in `ModeRegistry::from_config()`.
+pub struct ResponsePolicySection {
+    policy: String,
+}
+
+impl ResponsePolicySection {
+    pub fn new(policy: impl Into<String>) -> Self {
+        Self {
+            policy: policy.into(),
+        }
+    }
+}
+
+impl PromptSection for ResponsePolicySection {
+    fn name(&self) -> &str {
+        "response_policy"
+    }
+
+    fn build(&self, _ctx: &PromptContext<'_>) -> anyhow::Result<String> {
+        Ok(format!("## Response Policy\n\n{}", self.policy))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn make_ctx<'a>(
+        tools: &'a [Box<dyn crate::tools::Tool>],
+        skills: &'a [crate::skills::Skill],
+    ) -> PromptContext<'a> {
+        PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools,
+            skills,
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            dispatcher_instructions: "",
+        }
+    }
+
+    #[test]
+    fn name_is_response_policy() {
+        let s = ResponsePolicySection::new("respond when mentioned");
+        assert_eq!(s.name(), "response_policy");
+    }
+
+    #[test]
+    fn build_includes_header_and_policy_text() {
+        let tools: Vec<Box<dyn crate::tools::Tool>> = vec![];
+        let skills = vec![];
+        let ctx = make_ctx(&tools, &skills);
+        let s = ResponsePolicySection::new("respond when work items discussed");
+        let output = s.build(&ctx).unwrap();
+        assert!(output.starts_with("## Response Policy\n\n"));
+        assert!(output.contains("respond when work items discussed"));
+    }
+
+    #[test]
+    fn build_multiline_policy_preserved() {
+        let tools: Vec<Box<dyn crate::tools::Tool>> = vec![];
+        let skills = vec![];
+        let ctx = make_ctx(&tools, &skills);
+        let policy = "- respond when @mentioned\n- stay silent for social chat";
+        let s = ResponsePolicySection::new(policy);
+        let output = s.build(&ctx).unwrap();
+        assert!(output.contains("- respond when @mentioned"));
+        assert!(output.contains("- stay silent for social chat"));
+    }
+
+    #[test]
+    fn empty_policy_builds_without_error() {
+        let tools: Vec<Box<dyn crate::tools::Tool>> = vec![];
+        let skills = vec![];
+        let ctx = make_ctx(&tools, &skills);
+        let s = ResponsePolicySection::new("");
+        let output = s.build(&ctx).unwrap();
+        assert_eq!(output, "## Response Policy\n\n");
+    }
+}


### PR DESCRIPTION
## Summary

- **`src/modes/response_policy.rs`** (new): `ResponsePolicySection` implementing `PromptSection` — canonical reusable component for injecting `## Response Policy` blocks into mode system prompts via `SystemPromptBuilder`. Includes 4 unit tests covering name, header+body, multiline, and empty-policy cases.
- **`src/modes/mod.rs`**: exports `pub mod response_policy`
- **`src/channels/mod.rs`**: adds `user_facing_llm_error()` helper that translates raw Ollama error strings (service not running, model not pulled) into concise actionable Slack messages; replaces raw `format!("⚠️ Error: {e}")` at both LLM error send sites (draft-finalize path and normal send path)

## Context

The end-to-end pipeline (Slack → mode resolution → Ollama → visual identity → Slack) was already wired in W2's channel loop. Wave 3 delivers the remaining UX surface: a canonical `PromptSection` impl for response policies, and Ollama-specific error UX so users see actionable messages instead of raw provider stack traces.

## Stacks on

Depends on #3 (Wave 2 — Mode Layer).

## Test plan

- [x] `cargo build` — clean (pre-existing upstream warnings only)
- [x] `cargo test` — 19/19 modes tests pass, full suite passes
- [ ] Manual smoke test: `docker compose up`, mention bot, verify Ollama response flows through and visual identity is applied
- [ ] Manual error test: stop Ollama, verify Slack receives "Is Ollama running?" message instead of raw error

## Non-goals

- Tool calling (W4A — Linear)
- Wake/sleep (W4B)
- Interactive confirmation flows (W5)

## Risk and Rollback

- Risk: Low — no new dependencies, no config changes, no schema changes. `user_facing_llm_error` is a pure string transformation. `ResponsePolicySection` is additive and unused by current callers (response policy is inlined in `ModeRegistry::from_config` as in W2).
- Rollback: revert commit `8571114`

🤖 Generated with [Claude Code](https://claude.com/claude-code)