### PR TITLE
feat(webhook): Wave 6 — Webhooks & Lifecycle (V8)

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -324,7 +324,7 @@ impl SlackChannel {
             .remove(thread_key)
             .map(|h| h.abort());
 
-        let wake_sleep = Arc::clone(&self.wake_sleep);
+        let wake_sleep: Arc<WakeSleepEngine> = Arc::clone(&self.wake_sleep);
         let thread_key_owned = thread_key.to_string();
         let bot_token = self.bot_token.clone();
         let http_client = self.http_client();

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -308,6 +308,19 @@ pub struct LinearConfig {
     pub api_key: Option<String>,
     /// Default team ID for issue operations.
     pub team_id: Option<String>,
+    /// Port for the inbound webhook listener.
+    ///
+    /// When set, the daemon spawns an HTTP server on this port to receive
+    /// Linear project events and auto-create Slack channels.
+    /// Omit (or leave unset) to disable the webhook listener.
+    #[serde(default)]
+    pub webhook_port: Option<u16>,
+    /// HMAC-SHA256 signing secret from the Linear webhook settings page.
+    ///
+    /// When set, every inbound request is verified against the
+    /// `linear-signature` header. Strongly recommended in production.
+    #[serde(default)]
+    pub webhook_signing_secret: Option<String>,
 }
 
 // ── Hardware Config (wizard-driven) ─────────────────────────────

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -87,6 +87,19 @@ pub async fn run(config: Config, host: String, port: u16) -> Result<()> {
         tracing::info!("Cron disabled; scheduler supervisor not started");
     }
 
+    if config.linear.enabled && config.linear.webhook_port.is_some() {
+        let webhook_cfg = config.clone();
+        handles.push(spawn_component_supervisor(
+            "webhook",
+            initial_backoff,
+            max_backoff,
+            move || {
+                let cfg = webhook_cfg.clone();
+                async move { crate::webhook::run(&cfg).await }
+            },
+        ));
+    }
+
     println!("🧠 ZeroClaw daemon started");
     println!("   Gateway:  http://{host}:{port}");
     println!("   Components: gateway, channels, heartbeat, scheduler");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub mod tools;
 pub(crate) mod tunnel;
 pub(crate) mod util;
 pub(crate) mod wake_sleep;
+pub(crate) mod webhook;
 
 pub use config::Config;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,8 @@ mod skills;
 mod tools;
 mod tunnel;
 mod util;
+mod wake_sleep;
+mod webhook;
 
 use config::Config;
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -49,6 +49,7 @@ pub mod schedule;
 pub mod schema;
 pub mod screenshot;
 pub mod shell;
+pub mod slack_ops;
 pub mod traits;
 pub mod web_search_tool;
 

--- a/src/tools/slack_ops.rs
+++ b/src/tools/slack_ops.rs
@@ -1,0 +1,210 @@
+//! Slack channel lifecycle operations for the webhook handler.
+//!
+//! Provides helpers to create project-scoped channels and detect
+//! bidirectional links between Slack channels and Linear projects.
+
+use anyhow::{bail, Result};
+
+// ── Slug helpers ──────────────────────────────────────────────────────────────
+
+/// Convert a Linear project name into a Slack-safe channel slug.
+///
+/// Rules: lowercase, replace non-alphanumeric runs with `-`, prefix `prj-`,
+/// truncate to 80 chars (Slack limit).
+///
+/// `"Auth Refactor"` → `"prj-auth-refactor"`, `"Q1/2026 -- Infra"` → `"prj-q1-2026-infra"`
+pub fn project_name_to_slack_slug(name: &str) -> String {
+    let raw: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect();
+
+    // Collapse consecutive dashes, strip leading/trailing dashes.
+    let collapsed = raw
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+
+    let slug = format!("prj-{collapsed}");
+    slug.chars().take(80).collect()
+}
+
+/// Scan a Slack channel topic/description for an embedded Linear project URL.
+///
+/// Returns the URL if found, `None` otherwise.
+pub fn detect_channel_project_link(text: &str) -> Option<String> {
+    for word in text.split_whitespace() {
+        if word.starts_with("https://linear.app/") && word.contains("/project/") {
+            return Some(
+                word.trim_end_matches(|c: char| !c.is_alphanumeric())
+                    .to_string(),
+            );
+        }
+    }
+    None
+}
+
+// ── Channel lifecycle ─────────────────────────────────────────────────────────
+
+fn build_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_default()
+}
+
+/// Create a `#prj-<slug>` Slack channel for a new Linear project.
+///
+/// Steps:
+/// 1. Convert `project_name` → slug → channel name.
+/// 2. Call `conversations.create`.
+/// 3. Set channel topic with the Linear project URL.
+/// 4. Post a creation notice in the new channel.
+///
+/// Returns the Slack channel ID on success.
+pub async fn create_project_channel(
+    bot_token: &str,
+    project_name: &str,
+    linear_url: &str,
+) -> Result<String> {
+    let client = build_http_client();
+    let channel_name = project_name_to_slack_slug(project_name);
+
+    // 1. Create the channel.
+    let create_resp: serde_json::Value = client
+        .post("https://slack.com/api/conversations.create")
+        .bearer_auth(bot_token)
+        .json(&serde_json::json!({ "name": channel_name, "is_private": false }))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    if create_resp.get("ok") != Some(&serde_json::Value::Bool(true)) {
+        let err = create_resp
+            .get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or("unknown");
+
+        // name_taken is recoverable — just look up the existing channel.
+        if err == "name_taken" {
+            tracing::warn!("slack_ops: channel #{channel_name} already exists; skipping create");
+            return find_channel_id_by_name(bot_token, &channel_name).await;
+        }
+
+        bail!("conversations.create failed for #{channel_name}: {err}");
+    }
+
+    let channel_id = create_resp
+        .pointer("/channel/id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("conversations.create response missing channel.id"))?
+        .to_string();
+
+    // 2. Set topic to include bidirectional Linear link.
+    let topic = format!("Linear project: {linear_url}");
+    let _ = client
+        .post("https://slack.com/api/conversations.setTopic")
+        .bearer_auth(bot_token)
+        .json(&serde_json::json!({ "channel": channel_id, "topic": topic }))
+        .send()
+        .await;
+
+    // 3. Post creation notice.
+    let notice = format!(
+        ":white_check_mark: Channel created for Linear project *{project_name}*\n{linear_url}"
+    );
+    let _ = client
+        .post("https://slack.com/api/chat.postMessage")
+        .bearer_auth(bot_token)
+        .json(&serde_json::json!({ "channel": channel_id, "text": notice }))
+        .send()
+        .await;
+
+    tracing::info!("slack_ops: created #{channel_name} ({channel_id}) for {project_name}");
+    Ok(channel_id)
+}
+
+/// Resolve a channel ID by exact name match using `conversations.list`.
+///
+/// Used as a fallback when `name_taken` prevents channel creation.
+async fn find_channel_id_by_name(bot_token: &str, name: &str) -> Result<String> {
+    let client = build_http_client();
+    let resp: serde_json::Value = client
+        .get("https://slack.com/api/conversations.list")
+        .bearer_auth(bot_token)
+        .query(&[("exclude_archived", "true"), ("limit", "200")])
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    resp.get("channels")
+        .and_then(|c| c.as_array())
+        .into_iter()
+        .flatten()
+        .find_map(|ch| {
+            let ch_name = ch.get("name").and_then(|n| n.as_str())?;
+            let id = ch.get("id").and_then(|i| i.as_str())?;
+            if ch_name == name {
+                Some(id.to_string())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow::anyhow!("could not find existing channel #{name}"))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_simple_name() {
+        assert_eq!(
+            project_name_to_slack_slug("Auth Refactor"),
+            "prj-auth-refactor"
+        );
+    }
+
+    #[test]
+    fn slug_special_chars() {
+        assert_eq!(
+            project_name_to_slack_slug("Q1/2026 -- Infra"),
+            "prj-q1-2026-infra"
+        );
+    }
+
+    #[test]
+    fn slug_already_lowercase() {
+        assert_eq!(project_name_to_slack_slug("billing"), "prj-billing");
+    }
+
+    #[test]
+    fn slug_truncates_at_80_chars() {
+        let long_name = "a".repeat(90);
+        let slug = project_name_to_slack_slug(&long_name);
+        assert!(slug.len() <= 80, "slug must not exceed 80 chars");
+    }
+
+    #[test]
+    fn detect_link_present() {
+        let text = "Linear project: https://linear.app/acme/project/auth-refactor/ABC123";
+        assert!(detect_channel_project_link(text).is_some());
+    }
+
+    #[test]
+    fn detect_link_absent() {
+        assert!(detect_channel_project_link("no links here").is_none());
+    }
+
+    #[test]
+    fn detect_link_non_project_linear_url() {
+        let text = "See https://linear.app/acme/issue/ENG-123";
+        assert!(detect_channel_project_link(text).is_none());
+    }
+}

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,0 +1,275 @@
+//! Inbound webhook listener for Linear and GitHub events.
+//!
+//! Starts a standalone axum HTTP server on `[linear].webhook_port` and dispatches
+//! verified payloads to the appropriate handler. Each POST handler:
+//! 1. Reads the raw body.
+//! 2. Verifies the HMAC-SHA256 signature against `[linear].webhook_signing_secret`.
+//! 3. Parses the JSON payload.
+//! 4. Calls the relevant `slack_ops` function.
+
+use crate::config::Config;
+use crate::tools::slack_ops;
+use anyhow::{bail, Result};
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    routing::post,
+    Router,
+};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::sync::Arc;
+
+// ── Shared state ──────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct WebhookState {
+    bot_token: String,
+    signing_secret: Option<String>,
+}
+
+// ── Signature verification ────────────────────────────────────────────────────
+
+/// Verify a `linear-signature` or `X-Hub-Signature-256` HMAC-SHA256 header.
+///
+/// `header_value` should be the raw header value (Linear: bare hex, GitHub: `sha256=<hex>`).
+/// Returns `Ok(())` when the signature is valid or no secret is configured.
+/// Returns `Err` if a secret is present but the signature is missing or invalid.
+fn verify_hmac(body: &[u8], header_value: Option<&str>, secret: Option<&str>) -> Result<()> {
+    let Some(secret) = secret else {
+        return Ok(()); // no secret configured — accept all
+    };
+
+    let provided = header_value
+        .ok_or_else(|| anyhow::anyhow!("webhook: signature header missing"))?
+        .trim_start_matches("sha256=");
+
+    let expected = compute_hmac(body, secret);
+    if !constant_time_eq(expected.as_bytes(), provided.as_bytes()) {
+        bail!("webhook: signature mismatch");
+    }
+    Ok(())
+}
+
+fn compute_hmac(body: &[u8], secret: &str) -> String {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any length");
+    mac.update(body);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// Constant-time byte comparison to prevent timing attacks.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+// ── Route handlers ────────────────────────────────────────────────────────────
+
+/// POST /webhook/linear — receive Linear project events.
+async fn handle_linear(
+    State(state): State<Arc<WebhookState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    let sig = headers
+        .get("linear-signature")
+        .and_then(|v| v.to_str().ok());
+
+    if let Err(e) = verify_hmac(&body, sig, state.signing_secret.as_deref()) {
+        tracing::warn!("linear webhook: {e}");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let payload: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("linear webhook: invalid JSON — {e}");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    dispatch_linear_event(&state, &payload).await;
+    StatusCode::OK
+}
+
+/// POST /webhook/github — receive GitHub PR events.
+async fn handle_github(
+    State(state): State<Arc<WebhookState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    let sig = headers
+        .get("x-hub-signature-256")
+        .and_then(|v| v.to_str().ok());
+
+    if let Err(e) = verify_hmac(&body, sig, state.signing_secret.as_deref()) {
+        tracing::warn!("github webhook: {e}");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let payload: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("github webhook: invalid JSON — {e}");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    dispatch_github_event(&payload);
+    StatusCode::OK
+}
+
+// ── Event dispatchers ─────────────────────────────────────────────────────────
+
+async fn dispatch_linear_event(state: &WebhookState, payload: &serde_json::Value) {
+    let action = payload.get("action").and_then(|a| a.as_str()).unwrap_or("");
+    let type_ = payload.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+    tracing::debug!("linear webhook: type={type_} action={action}");
+
+    // Project created → auto-create a Slack channel.
+    if type_ == "Project" && action == "create" {
+        on_linear_project_create(state, payload).await;
+    }
+}
+
+async fn on_linear_project_create(state: &WebhookState, payload: &serde_json::Value) {
+    let name = payload
+        .pointer("/data/name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Unnamed Project");
+
+    let url = payload
+        .pointer("/data/url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    match slack_ops::create_project_channel(&state.bot_token, name, url).await {
+        Ok(ch) => tracing::info!("linear webhook: created Slack channel {ch} for '{name}'"),
+        Err(e) => tracing::error!("linear webhook: failed to create channel for '{name}': {e}"),
+    }
+}
+
+fn dispatch_github_event(payload: &serde_json::Value) {
+    let action = payload.get("action").and_then(|a| a.as_str()).unwrap_or("");
+    let merged = payload
+        .pointer("/pull_request/merged")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    tracing::debug!("github webhook: action={action} merged={merged}");
+
+    // PR merged → log for future lifecycle hooks (stub for now).
+    if action == "closed" && merged {
+        let pr_title = payload
+            .pointer("/pull_request/title")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)");
+        let pr_url = payload
+            .pointer("/pull_request/html_url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        tracing::info!("github webhook: PR merged — '{pr_title}' {pr_url}");
+    }
+}
+
+// ── Server startup ────────────────────────────────────────────────────────────
+
+/// Start the webhook HTTP listener. Runs until cancelled.
+///
+/// Requires `config.linear.webhook_port` to be `Some`. If `config.linear.webhook_signing_secret`
+/// is set, all requests must carry a valid HMAC-SHA256 signature.
+pub async fn run(config: &Config) -> Result<()> {
+    let port = config
+        .linear
+        .webhook_port
+        .ok_or_else(|| anyhow::anyhow!("webhook: linear.webhook_port not configured"))?;
+
+    let bot_token = config
+        .channels_config
+        .slack
+        .as_ref()
+        .map(|s| s.bot_token.clone())
+        .ok_or_else(|| anyhow::anyhow!("webhook: [channels.slack] bot_token required"))?;
+
+    let state = Arc::new(WebhookState {
+        bot_token,
+        signing_secret: config.linear.webhook_signing_secret.clone(),
+    });
+
+    let app = Router::new()
+        .route("/webhook/linear", post(handle_linear))
+        .route("/webhook/github", post(handle_github))
+        .with_state(state);
+
+    let addr = format!("0.0.0.0:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!("webhook: listening on {addr}");
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hmac_valid_signature() {
+        let body = b"hello world";
+        let secret = "mysecret";
+        let sig = compute_hmac(body, secret);
+        assert!(verify_hmac(body, Some(&sig), Some(secret)).is_ok());
+    }
+
+    #[test]
+    fn hmac_invalid_signature() {
+        let body = b"hello world";
+        assert!(verify_hmac(body, Some("deadbeef"), Some("mysecret")).is_err());
+    }
+
+    #[test]
+    fn hmac_missing_header_with_secret() {
+        let body = b"hello world";
+        assert!(verify_hmac(body, None, Some("mysecret")).is_err());
+    }
+
+    #[test]
+    fn hmac_no_secret_always_ok() {
+        let body = b"hello world";
+        assert!(verify_hmac(body, None, None).is_ok());
+    }
+
+    #[test]
+    fn hmac_github_sha256_prefix_stripped() {
+        let body = b"payload";
+        let secret = "ghs";
+        let raw = compute_hmac(body, secret);
+        let prefixed = format!("sha256={raw}");
+        assert!(verify_hmac(body, Some(&prefixed), Some(secret)).is_ok());
+    }
+
+    #[test]
+    fn constant_time_eq_matching() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+    }
+
+    #[test]
+    fn constant_time_eq_different_length() {
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn constant_time_eq_different_content() {
+        assert!(!constant_time_eq(b"abc", b"xyz"));
+    }
+}


### PR DESCRIPTION
## Summary

- New `src/webhook.rs`: standalone axum HTTP server on `linear.webhook_port`, handling `POST /webhook/linear` and `POST /webhook/github` with HMAC-SHA256 signature verification
- New `src/tools/slack_ops.rs`: Slack channel lifecycle — `create_project_channel`, `detect_channel_project_link`, `project_name_to_slack_slug` with graceful `name_taken` handling
- Extended `LinearConfig` with `webhook_port: Option<u16>` and `webhook_signing_secret: Option<String>` (additive, default `None`)
- Wired webhook supervisor into `daemon/mod.rs` — starts when `linear.enabled && linear.webhook_port.is_some()`
- Fixed pre-existing binary compile errors: `Arc<WakeSleepEngine>` type annotation, missing `mod wake_sleep` in binary

## Demo

```toml
[linear]
enabled = true
webhook_port = 3001
webhook_signing_secret = "<from Linear webhook settings>"
```

Create "Auth Refactor" project in Linear → Linear fires webhook → `#prj-auth-refactor` created in Slack with Linear project URL in topic.

## Test plan

- [x] `cargo build` passes (lib + bin)
- [x] `cargo test` passes (all 2969 tests)
- [x] `cargo fmt --check` clean
- [x] No clippy errors in new files

## Non-goals

- GitHub PR merged event is stubbed (logs only) — lifecycle hooks deferred to W7
- No UI for webhook config — TOML only

## Risk and Rollback

- Risk: Low — two new files; existing files minimally touched (additive config fields, daemon supervisor conditional on new config key)
- Rollback: remove `[linear] webhook_port` from config → supervisor never starts; or revert this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook listener for Linear and GitHub events with configurable port and optional HMAC-SHA256 signature verification to ensure secure inbound requests and prevent unauthorized access.
  * Implemented automatic Slack channel creation and setup for Linear projects, including intelligent slug generation, topic linking to the project, and creation notifications posted in the new channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->