### PR TITLE
feat(ops): Claude Code ↔ Mattermost MCP bridge (#53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,13 +104,13 @@ npm install && npm run build
 # 4. Add to ~/.claude/settings.json (see below), then restart Claude Code
 ```
 
-**`~/.claude/settings.json` entry** (add under `"mcpServers"`):
+**`~/.claude/settings.json` entry** (add under `"mcpServers"`, substitute your actual path):
 
 ```json
 "mcpServers": {
   "mattermost": {
     "command": "node",
-    "args": ["/Users/cmbays/Github/mattermost-mcp/build/index.js"]
+    "args": ["<absolute-path-to>/mattermost-mcp/build/index.js"]
   }
 }
 ```


### PR DESCRIPTION
## Summary

Closes #53. Wires up [pvev/mattermost-mcp](https://github.com/pvev/mattermost-mcp) (MIT) as a
Claude Code MCP server, giving every session direct read/write access to Mattermost channels.

**Problem**: Claude Code sessions had no direct way to read or post in Mattermost channels,
requiring manual web UI interaction to coordinate with bots.

**What changed**:
- `CLAUDE.md`: Add "Claude Code ↔ Mattermost MCP Bridge" section — tool reference table,
  one-time setup steps, and the `~/.claude/settings.json` entry needed to activate it.
- `scripts/setup-mattermost-mcp.sh`: New executable script that generates
  `config.local.json` (gitignored in the MCP server clone) from `.envrc.mattermost` credentials.
  Passes secrets via environment to Python (never interpolated into source code).
  Validates HTTP status before accepting API response as team ID. Checks prerequisites.
  Token priority: `MM_CLAUDE_TOKEN` > `MM_ADMIN_TOKEN` > `MM_TOKEN_SOKKA`.

## Validation Evidence

Local validation run (2026-02-26):
- `bash -n scripts/setup-mattermost-mcp.sh` → Syntax OK
- Script executed against live Mattermost: team `zeroclaw-hq` resolved, `config.local.json` written
- MCP server started: `node ~/Github/mattermost-mcp/build/index.js` → "Successfully initialized Mattermost client"
- Round-trip verified: `mattermost_list_channels` returned 10 channels; `mattermost_post_message` to #general confirmed in channel history
- CI gate: Non-Rust Fast Path ✅, Docs Quality ✅, CI Required Gate ✅

## Security Impact

- **Risk**: Low. Shell script + docs only; no Rust code changes.
- **Secret handling**: Credentials are sourced from `.envrc.mattermost` (gitignored) and passed
  to Python via environment variables — never interpolated into heredoc source code.
- **HTTP validation**: curl checks HTTP status code before accepting response body as a team ID,
  preventing Mattermost error objects from silently becoming config values.
- `config.local.json` holds live token and team ID. It is gitignored in pvev/mattermost-mcp repo.
  Not committed anywhere.

## Privacy and Data Hygiene

- No personal data, real names, emails, tokens, or real URLs committed to the repo.
- CLAUDE.md example `settings.json` uses placeholder `<absolute-path-to>/...` (not a real path).
- Setup script logs token label only (`MM_CLAUDE_TOKEN`, `MM_ADMIN_TOKEN`, etc.) — never the token value.
- API error responses display only the parsed `message` field — not the raw token-adjacent request context.

## Rollback Plan

1. `git revert ea38a3cf 81c5c74a de883f4b` — removes CLAUDE.md section and setup script.
2. Remove `mcpServers.mattermost` from `~/.claude/settings.json` on each machine using it.
3. `config.local.json` in the mattermost-mcp clone can be deleted; it is gitignored there.

## Non-goals

- Modifying pvev/mattermost-mcp source (used as-is)
- Adding env-var support to the MCP server itself
- Dedicated "claude-code" Mattermost user (using admin token as fallback for now; add `MM_CLAUDE_TOKEN` when ready)

## Notes

- The Mattermost team is `zeroclaw-hq` (not `zeroclaw`). Note: `config/config.toml` has a stale `team_id` value that does not match the live instance — bots are unaffected since they connect via bot token, not team ID.
- Part of Epic #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for the Claude Code ↔ Mattermost MCP Bridge integration with setup steps, tool descriptions, and configuration examples.

* **New Features**
  * Added an automated setup utility to generate local bridge configuration, manage credentials, validate team identity, and guide next steps with clear status and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->