### PR TITLE
fix(ops): set ZEROCLAW_MODEL=qwen3:8b in docker-compose shared template

### DIFF
--- a/docker-compose.fork.yml
+++ b/docker-compose.fork.yml
@@ -21,6 +21,7 @@ x-zeroclaw-bot: &zeroclaw-bot
   command: ["daemon"]
   environment:
     - RUST_LOG=zeroclaw=info
+    - ZEROCLAW_MODEL=qwen3:8b
   extra_hosts:
     - "host.docker.internal:host-gateway"
   networks:


### PR DESCRIPTION
## Summary
- Add `ZEROCLAW_MODEL=qwen3:8b` to the `x-zeroclaw-bot` shared template in `docker-compose.fork.yml`

## Context
The Dockerfile bakes `llama3.2` as the default model via `ENV ZEROCLAW_MODEL=llama3.2`. The `default_model` key in per-bot TOML configs does not override this env var — the env var takes precedence. Without the explicit override in docker-compose, all bots run `llama3.2` regardless of config.

Should have been included in PR #58 but was missed.

## Changes
- `docker-compose.fork.yml`: 1 line added

## Risk and Rollback
- **Risk**: Low — additive env var, no behavior change for bots already running qwen3:8b
- **Rollback**: Remove the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)