### PR TITLE
feat(sokka): expand tool_allowlist — apply_patch, process, docx_read

### DIFF
--- a/config/sokka.example.toml
+++ b/config/sokka.example.toml
@@ -8,7 +8,7 @@ default_model = "qwen3:4b"
 api_key = "http://localhost:11434"
 default_temperature = 0.3
 
-tool_allowlist = ["shell", "file_read", "file_write", "file_edit", "glob", "content_search", "ask_user"]
+tool_allowlist = ["shell", "file_read", "file_write", "file_edit", "glob", "content_search", "ask_user", "apply_patch", "process", "docx_read"]
 
 [agent]
 compact_context = false   # keep full context for code/file workflows


### PR DESCRIPTION
## Summary

Wires three tools from the upstream sync (PR #61) into Sokka's `tool_allowlist`:

- **`apply_patch`** — surgical unified-diff edits; built-in `git apply --check` prevents corrupted files; useful for self-healing CI fix loops
- **`process`** — spawn long-running background jobs (e.g. `cargo test --release`, `docker compose up`) without hitting the 120s timeout
- **`docx_read`** — read Word docs (design specs, PRDs, runbooks) dropped in Mattermost

## Change

`config/sokka.example.toml` — one-line `tool_allowlist` update.

## Non-goals

- No changes to `src/` — all three tools are already registered in `src/tools/mod.rs` (upstream)
- No identity file changes

## Risk and Rollback

- Risk: XS — config template only; no behavior changes to any source file
- Rollback: revert the one-line edit

Closes #63