### PR TITLE
fix(security): add SSRF protection to LinearTool (#65)

### DIFF
--- a/src/tools/linear.rs
+++ b/src/tools/linear.rs
@@ -17,7 +17,7 @@ const LINEAR_API_URL: &str = "https://api.linear.app/graphql";
 /// Validate that `url` is the Linear GraphQL endpoint — HTTPS only, `api.linear.app` only,
 /// with private-IP blocking. Called before every reqwest call in [`LinearTool::graphql`].
 fn validate_linear_url(url: &str) -> anyhow::Result<()> {
-    let allowed = vec!["api.linear.app".to_string()];
+    let allowed = ["api.linear.app".to_string()];
     validate_url(
         url,
         &DomainPolicy {


### PR DESCRIPTION
## Problem

`LinearTool::graphql()` called `self.client.post(LINEAR_API_URL)` with no
URL validation, leaving a SSRF surface open if the constant or call site
were ever changed. No private-IP blocking or scheme enforcement existed.

## Change

- Imports `validate_url` / `DomainPolicy` / `UrlSchemePolicy` from the
  shared `url_validation` module and `UrlAccessConfig` from config.
- Adds a module-level `validate_linear_url(url: &str)` function that:
  - Allows only the `api.linear.app` domain (allowlist).
  - Requires HTTPS (`UrlSchemePolicy::HttpsOnly`).
  - Blocks private IPs / local hosts via `UrlAccessConfig::default()`.
- Calls `validate_linear_url(LINEAR_API_URL)?` at the top of `graphql()`
  before every reqwest call.
- Adds test `linear_tool_rejects_non_linear_url` covering:
  - `https://api.linear.app/graphql` passes.
  - `https://evil.com/graphql` rejected (allowlist).
  - `https://192.168.1.1/graphql` rejected (allowlist).
  - `http://api.linear.app/graphql` rejected (scheme).

## Non-goals

- No new config surface — the endpoint is always hard-coded.
- No behavior change for valid requests.

## Risk and Rollback

Risk: Low — validation always passes for the constant `LINEAR_API_URL`;
no functional change for valid usage.
Rollback: revert this commit.

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for connections to the Linear GraphQL endpoint by enforcing allowed host and HTTPS-only access and blocking non-public addresses.

* **Tests**
  * Added tests covering the new Linear endpoint validation to ensure connection rules are enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->