### PR TITLE
chore(docs): adapt PR template for fork workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Describe this PR in 2-5 bullets:
 
-- Base branch target (`main` or `dev`; direct `main` PRs are allowed):
+- Base branch target (`dev`; all PRs target `dev` — `main` is upstream mirror only):
 - Problem:
 - Why it matters:
 - What changed:
@@ -28,8 +28,7 @@ Describe this PR in 2-5 bullets:
 - Related #
 - Depends on # (if stacked)
 - Supersedes # (if replacing older PR)
-- Linear issue key(s) (required, e.g. `RMN-123`):
-- Linear issue URL(s):
+- Linear issue key(s) (N/A — upstream zeroclaw tracker; omit for fork PRs):
 
 ## Supersede Attribution (required when `Supersedes #` is used)
 


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: PR template inherited from upstream requires `RMN/CDV/COM` Linear issue keys that fork PRs will never have, causing persistent Intake Checks CI failures and confusing contributors
- Why it matters: Reduces noise and makes the N/A status self-documenting
- What changed: Removed upstream Linear key fields; clarified `dev`-only base branch policy
- What did **not** change: All four required sections (`Validation Evidence`, `Security Impact`, `Privacy and Data Hygiene`, `Rollback Plan`) preserved as-is — they're good practice regardless of upstream origin

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `docs`, `ci`

## Change Metadata

- Change type: `chore`
- Primary scope: `docs`

## Linked Issue

- Closes: N/A
- Linear issue key(s) (N/A — upstream zeroclaw tracker; omit for fork PRs):

## Validation Evidence (required)

- No code changed; docs/template only
- `git diff` reviewed — 2 lines removed, 2 lines modified, no accidental deletions

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- No PII or sensitive data touched

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Rollback Plan (required)

- Fast rollback command: `git revert HEAD` on `dev`
- Observable failure symptoms: N/A (docs-only change)