### PR TITLE
docs(planning): tool_allowlist upstream evaluation — keep as-is, defer contribution (#66)

### DIFF
--- a/docs/planning/DECISIONS.md
+++ b/docs/planning/DECISIONS.md
@@ -61,6 +61,59 @@
 | **Branch strategy** | `main` = upstream mirror, `dev` = integration, `feat/*` = feature branches | Keeps clean upstream sync. PRs merge into `dev`. |
 | **Upstream sync** | `git fetch upstream && git merge --ff-only upstream/main` then merge into `dev` | Feature flags isolate fork changes, most upstream merges are clean. |
 
+## tool_allowlist upstream evaluation (2026-02-28)
+
+**Issue**: #66 — Should `tool_allowlist` be contributed upstream, replaced by an upstream equivalent, or kept as-is?
+
+### What the fork has
+
+`Config.tool_allowlist: Vec<String>` (top-level, `src/config/schema.rs`) + `apply_tool_allowlist()` (`src/agent/agent.rs`).
+
+Behaviour: if non-empty, the tool registry is filtered *at agent build time* — the model only sees the listed tools.
+Implementation: 16 lines of logic, 4 unit tests. All 6 bot configs use it to define per-bot capability profiles.
+
+### What upstream has (audited 2026-02-28)
+
+| Upstream mechanism | Location | Purpose |
+|--------------------|----------|---------|
+| `AutonomyConfig.auto_approve` / `always_ask` | `[autonomy]` | **Approval gates** — controls whether a human must confirm a tool call. Does NOT filter which tools are presented to the model. |
+| `AutonomyConfig.non_cli_excluded_tools` | `[autonomy]` | Excludes tools when running as a daemon/service. Runtime-mode exclusion, not per-bot. |
+| `SubAgentConfig.allowed_tools` | `[[agents]]` | Allowlist for sub-agents in agentic mode. Only applies to spawned sub-agents, not the top-level process agent. |
+| `SecurityRoleConfig.allowed_tools` / `denied_tools` | `[security.roles]` | RBAC per-role tool access, enforced at *execution time* via `RoleRegistry.resolve_tool_access()`. Not wired to tool registration; the model still sees all tools. Requires role definitions + user-role assignment. |
+| `AgentConfig` | `[agent]` | Behavioural settings (iterations, history, dispatcher). No tool restriction field. |
+
+**Gap confirmed**: upstream has no simple per-bot build-time tool filter. The security-roles path is structurally different (runtime RBAC vs. registration-time allowlist) and operationally heavier (requires role config per user, not per bot process).
+
+### Decision: **Keep as-is — defer upstream contribution**
+
+Rationale:
+
+1. **No upstream equivalent.** The closest upstream mechanism (`security.roles`) operates at execution time and targets user permissions, not bot capability profiles. It cannot replace `tool_allowlist` without significant operational overhead.
+
+2. **Feature works correctly.** No bugs, no performance concerns, zero fork-specific dependencies.
+
+3. **Contribution barrier is process, not technical.** Upstream PR template requires a Linear issue key (`RMN-XXX`) marked as required. All recent merged PRs are from the core maintainer team. A clean external contribution is possible but requires opening a Linear issue with the upstream team first — that step hasn't happened.
+
+4. **Better upstream placement would be `AgentConfig`, not top-level `Config`.** If contributed, the field belongs under `[agent]` alongside `max_tool_iterations`, `parallel_tools`, etc. But that refactor is a breaking config change for all 6 bot configs (move `tool_allowlist = [...]` from root → `[agent]` section). This refactor cost isn't justified until upstream confirms they want the feature.
+
+5. **Low sync risk at current placement.** The field is appended at the tail of `Config` defaults, minimally invasive to upstream syncs.
+
+### Defer until
+
+Open a GitHub issue on `zeroclaw-labs/zeroclaw` proposing `AgentConfig.tool_allowlist`. If maintainer confirms interest:
+- Refactor: move `Config.tool_allowlist` → `AgentConfig.tool_allowlist` in `schema.rs` + `agent.rs`
+- Update all 6 bot configs: move `tool_allowlist = [...]` from root into `[agent]` section
+- Add `docs/config-reference.md` entry (upstream requirement for config additions)
+- Open upstream PR with one integration test using their `DummyProvider` mock pattern
+
+### Rejected alternatives
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Migrate to `security.roles` | RBAC at execution time ≠ build-time capability profiles. Requires role definitions per user. Operationally heavier, semantically different. |
+| Immediate upstream contribution | Requires Linear issue key + Track B review + docs update. Premature before maintainer interest is confirmed. |
+| Move to `AgentConfig` now | Breaking config change across 6 bot configs with no upstream payoff yet. |
+
 ## Rejected Alternatives
 
 | Rejected | Why |


### PR DESCRIPTION
## Summary

- **Problem**: Issue #66 asked whether our fork's `tool_allowlist` should be contributed upstream, replaced by an upstream equivalent, or kept as-is.
- **What changed**: `docs/planning/DECISIONS.md` updated with research findings and decision.
- **What did not change**: No code changes. `tool_allowlist` implementation unchanged.
- **Scope boundary**: Docs-only. No code, config, or test changes.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `docs`

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes #66

## Research Findings

Audited upstream `src/config/schema.rs` and `src/agent/agent.rs` on 2026-02-28.

**Upstream has no equivalent** for a simple per-bot build-time tool filter:

| Upstream mechanism | Purpose | Gap |
|--------------------|---------|-----|
| `AutonomyConfig.auto_approve`/`always_ask` | Approval gates (human-in-loop) | Different purpose — does not filter model's tool view |
| `AutonomyConfig.non_cli_excluded_tools` | Runtime-mode exclusions | Per-mode, not per-bot |
| `SubAgentConfig.allowed_tools` | Sub-agent scoped allowlist | Only applies to spawned sub-agents |
| `SecurityRoleConfig.allowed_tools`/`denied_tools` | RBAC at execution time via `RoleRegistry` | Different architecture — not wired to tool registration |
| `AgentConfig` | Behavioural settings | No tool restriction field |

**Decision: keep as-is, defer contribution** until upstream maintainer confirms interest via a GitHub issue on `zeroclaw-labs/zeroclaw`. If confirmed, refactor target is `AgentConfig` (which would require updating 6 bot configs).

Full rationale in `docs/planning/DECISIONS.md`.

## Validation Evidence (required)

Docs-only change. No cargo commands needed.

- `docs/planning/DECISIONS.md` appended (no existing content modified)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Neutral wording: project-scoped labels used throughout

## Compatibility / Migration

- Backward compatible? Yes (docs only)
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (internal planning doc, not user-facing docs)

## Human Verification (required)

- Verified upstream schema fields exist as described by reading live upstream files via `gh api`
- Verified `RoleRegistry.resolve_tool_access()` is NOT called from agent tool registration path (only from `src/security/roles.rs`)
- Verified all 6 bot configs actively use `tool_allowlist`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: docs only
- Potential unintended effects: none
- Guardrails: n/a

## Rollback Plan (required)

- Revert the single commit `1d994dd9`