### PR TITLE
refactor(config): move tool_allowlist from Config to AgentConfig (#66)

### DIFF
--- a/config/aang.example.toml
+++ b/config/aang.example.toml
@@ -6,11 +6,10 @@ default_model = "qwen3:4b"
 api_key = "http://localhost:11434"
 default_temperature = 0.5
 
-tool_allowlist = ["delegate", "memory_store", "memory_recall", "ask_user"]
-
 [agent]
 compact_context = false
 skills_prompt_mode = "compact"
+tool_allowlist = ["delegate", "memory_store", "memory_recall", "ask_user"]
 
 [identity]
 format = "aieos"

--- a/config/azula.example.toml
+++ b/config/azula.example.toml
@@ -6,11 +6,10 @@ default_model = "qwen3:4b"
 api_key = "http://localhost:11434"
 default_temperature = 0.1
 
-tool_allowlist = ["content_search", "file_read", "glob", "ask_user"]
-
 [agent]
 compact_context = false
 skills_prompt_mode = "compact"
+tool_allowlist = ["content_search", "file_read", "glob", "ask_user"]
 
 [identity]
 format = "aieos"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -17,8 +17,11 @@ default_provider    = "ollama"
 default_model       = "qwen3:14b"
 default_temperature = 0.5
 
-# Tool ceiling — empty means all registered tools are offered.
-tool_allowlist = []
+# ── Agent ───────────────────────────────────────────────────────────────────────
+# tool_allowlist: capability profile for this bot. Empty (default) = all registered tools offered.
+
+[agent]
+# tool_allowlist = ["shell", "file_read", "linear"]  # uncomment and populate to restrict tools
 
 # ── Identity ────────────────────────────────────────────────────────────────────
 # Each bot process has one identity. Point to the bot's AIEOS JSON file.

--- a/config/iroh.example.toml
+++ b/config/iroh.example.toml
@@ -6,11 +6,10 @@ default_model = "qwen3:4b"
 api_key = "http://localhost:11434"
 default_temperature = 0.8
 
-tool_allowlist = ["memory_store", "memory_recall", "ask_user"]
-
 [agent]
 compact_context = false
 skills_prompt_mode = "compact"
+tool_allowlist = ["memory_store", "memory_recall", "ask_user"]
 
 [identity]
 format = "aieos"

--- a/config/katara.example.toml
+++ b/config/katara.example.toml
@@ -7,8 +7,6 @@ default_model = "qwen3:4b"
 api_key = "http://localhost:11434"
 default_temperature = 0.1
 
-tool_allowlist = ["linear", "memory_store", "memory_recall", "memory_forget", "ask_user", "file_read", "docx_read"]
-
 [research]
 enabled = true
 trigger = "keywords"
@@ -27,6 +25,7 @@ target = "pm-updates"
 [agent]
 compact_context = false   # keep full context for multi-issue PM workflows
 skills_prompt_mode = "compact"
+tool_allowlist = ["linear", "memory_store", "memory_recall", "memory_forget", "ask_user", "file_read", "docx_read"]
 
 [identity]
 format = "aieos"

--- a/config/sokka.example.toml
+++ b/config/sokka.example.toml
@@ -8,12 +8,11 @@ default_model = "qwen3:4b"
 api_key = "http://localhost:11434"
 default_temperature = 0.3
 
-tool_allowlist = ["shell", "file_read", "file_write", "file_edit", "glob", "content_search", "ask_user", "apply_patch", "process", "docx_read"]
-
 [agent]
 compact_context = false   # keep full context for code/file workflows
 parallel_tools = true     # concurrent file reads and shell ops
 skills_prompt_mode = "compact"
+tool_allowlist = ["shell", "file_read", "file_write", "file_edit", "glob", "content_search", "ask_user", "apply_patch", "process", "docx_read"]
 
 [identity]
 format = "aieos"

--- a/config/toph.example.toml
+++ b/config/toph.example.toml
@@ -6,11 +6,10 @@ default_model = "qwen3:4b"
 api_key = "http://localhost:11434"
 default_temperature = 0.3
 
-tool_allowlist = ["shell", "file_read", "http_request", "ask_user"]
-
 [agent]
 compact_context = false
 skills_prompt_mode = "compact"
+tool_allowlist = ["shell", "file_read", "http_request", "ask_user"]
 
 [identity]
 format = "aieos"

--- a/docs/planning/upstream-proposals.md
+++ b/docs/planning/upstream-proposals.md
@@ -1,0 +1,76 @@
+# Upstream Contribution Proposals
+
+Tracking active and potential contributions from this fork back to
+[zeroclaw-labs/zeroclaw](https://github.com/zeroclaw-labs/zeroclaw).
+
+---
+
+## How to Contribute Upstream
+
+The upstream repo is open source (MIT) and accepts external PRs to the `dev` branch.
+The practical pathway for external contributors:
+
+1. **Open a GitHub issue** on `zeroclaw-labs/zeroclaw` describing the proposed change.
+   This is the primary communication channel. The maintainer team can then create a
+   Linear issue (`RMN-XXX`) on their end and link it back to you.
+
+2. **Wait for a "go ahead"** signal in the issue. For small, clean config additions this
+   is usually fast if the feature fits the project direction.
+
+3. **Fork, branch, and PR**. Target `dev`. Follow the PR template fully:
+   - Include the Linear issue key provided by maintainers (or ask them to provide one).
+   - Follow Track B (medium-risk) process for config/behavior changes.
+   - Add/update `docs/config-reference.md` for any new config keys.
+   - Include at least one integration test using the `DummyProvider` mock pattern.
+   - Run `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test`.
+
+**Re: the Linear issue key requirement**: The PR template marks this as "required"
+(`Linear issue key(s) (required, e.g. RMN-123)`). In practice this means the maintainers
+use Linear for their internal sprint tracking. External contributors cannot create Linear
+issues directly — but you can ask a maintainer to create one in the issue thread before
+submitting the PR. This is a normal OSS workflow: maintainer triages the GitHub issue and
+creates their internal ticket, then the contributor references it in the PR.
+
+---
+
+## Proposal: `AgentConfig.tool_allowlist`
+
+**Status**: GitHub issue not yet opened — pending this fork's refactor landing first.
+
+**What**: Add `tool_allowlist: Vec<String>` to `AgentConfig` in `src/config/schema.rs`.
+
+**Why it fits upstream**:
+- `AgentConfig` already groups per-agent behavioral settings (`max_tool_iterations`,
+  `parallel_tools`, `tool_dispatcher`, etc.). A capability profile field fits naturally.
+- Zero new dependencies. 16 lines of implementation (`apply_tool_allowlist()` in
+  `src/agent/agent.rs`). 4 unit tests.
+- Useful for any multi-bot deployment where different agent processes need different
+  tool subsets (security hardening, capability focus, resource limiting).
+- Upstream already has `SubAgentConfig.allowed_tools` for sub-agents — this extends
+  the same concept to the top-level agent process.
+
+**What a clean upstream PR would include**:
+- `schema.rs`: `tool_allowlist: Vec<String>` field on `AgentConfig` with `#[serde(default)]`
+- `agent.rs`: `apply_tool_allowlist(tools, &config.agent.tool_allowlist)` call in
+  `from_config_with_runtime()`, after `all_tools_with_runtime()`
+- `docs/config-reference.md`: entry under `[agent]` section documenting the field,
+  empty-default semantics, and an example
+- Tests: at minimum the 4 unit tests in `agent.rs`; ideally one integration test
+  using `DummyProvider` that verifies tool count before/after allowlist
+
+**Fork implementation reference**: `src/agent/agent.rs:249-266` + `src/agent/agent.rs:332-333`
+
+**Next action**: Open a GitHub issue on `zeroclaw-labs/zeroclaw` once PR #77 (this
+refactor) is merged to dev. Link: https://github.com/zeroclaw-labs/zeroclaw/issues
+
+---
+
+## Notes on Upstream Contribution Pace
+
+As of 2026-02-28, all merged PRs in the upstream repo are from the core maintainer
+team (`theonlyhennygod`, `chumyin`). This is common for young open source projects
+that have been primarily maintainer-driven. It does not mean external contributions
+are unwelcome — the `CONTRIBUTING.md` explicitly invites them and outlines tracks A/B/C.
+
+Track A (docs, tests, chore) is the fastest path to a first merged PR and helps build
+the contributor relationship before attempting Track B config changes.

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -330,7 +330,7 @@ impl Agent {
         );
 
         // Apply tool_allowlist: if non-empty, restrict tools exposed to the model.
-        let tools = apply_tool_allowlist(tools, &config.tool_allowlist);
+        let tools = apply_tool_allowlist(tools, &config.agent.tool_allowlist);
 
         let provider_name = config.default_provider.as_deref().unwrap_or("openrouter");
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -292,11 +292,6 @@ pub struct Config {
     #[serde(default)]
     pub team: TeamConfig,
 
-    /// Tool allowlist: if non-empty, only these tool names will be available to the model.
-    /// Used for per-bot tool restriction (fork addition).
-    #[serde(default)]
-    pub tool_allowlist: Vec<String>,
-
     /// Linear integration configuration (`[linear]` section, fork addition).
     #[serde(default)]
     pub linear: LinearConfig,
@@ -810,6 +805,11 @@ pub struct AgentConfig {
     /// set to `0` for explicit disable.
     #[serde(default = "default_safety_heartbeat_turn_interval")]
     pub safety_heartbeat_turn_interval: usize,
+    /// Tool allowlist: if non-empty, only these tool names will be available to the model.
+    /// Defines the capability profile for this bot process. Empty = all registered tools exposed.
+    /// Fork addition — proposed for upstream `AgentConfig`; see docs/planning/DECISIONS.md.
+    #[serde(default)]
+    pub tool_allowlist: Vec<String>,
 }
 
 fn default_agent_max_tool_iterations() -> usize {
@@ -857,6 +857,7 @@ impl Default for AgentConfig {
             loop_detection_failure_streak: default_loop_detection_failure_streak(),
             safety_heartbeat_interval: default_safety_heartbeat_interval(),
             safety_heartbeat_turn_interval: default_safety_heartbeat_turn_interval(),
+            tool_allowlist: Vec::new(),
         }
     }
 }
@@ -5615,7 +5616,6 @@ impl Default for Config {
             model_support_vision: None,
             wasm: WasmConfig::default(),
             team: TeamConfig::default(),
-            tool_allowlist: Vec::new(),
             linear: LinearConfig::default(),
         }
     }
@@ -8702,7 +8702,6 @@ default_temperature = 0.7
             model_support_vision: None,
             wasm: WasmConfig::default(),
             team: TeamConfig::default(),
-            tool_allowlist: Vec::new(),
             linear: LinearConfig::default(),
         };
 
@@ -9077,7 +9076,6 @@ tool_dispatcher = "xml"
             model_support_vision: None,
             wasm: WasmConfig::default(),
             team: TeamConfig::default(),
-            tool_allowlist: Vec::new(),
             linear: LinearConfig::default(),
         };
 

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -200,7 +200,6 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         model_support_vision: None,
         wasm: crate::config::WasmConfig::default(),
         team: crate::config::TeamConfig::default(),
-        tool_allowlist: Vec::new(),
         linear: crate::config::LinearConfig::default(),
     };
 
@@ -568,7 +567,6 @@ async fn run_quick_setup_with_home(
         model_support_vision: None,
         wasm: crate::config::WasmConfig::default(),
         team: crate::config::TeamConfig::default(),
-        tool_allowlist: Vec::new(),
         linear: crate::config::LinearConfig::default(),
     };
     if no_totp {


### PR DESCRIPTION
## Summary

- **Problem**: `tool_allowlist` was orphaned at the top level of `Config`, between `[team]` and `[linear]`. It belongs with the other per-agent behavioral settings in `AgentConfig` (`[agent]`).
- **What changed**: Field moved `Config → AgentConfig` in `schema.rs`; one-line update in `agent.rs` and `wizard.rs`; all 6 example configs updated; `docs/planning/upstream-proposals.md` added documenting the upstream contribution pathway.
- **What did not change**: Behaviour is identical. `tool_allowlist` still filters the tool registry at agent build time. Empty = all tools exposed.
- **Scope boundary**: Config structural refactor only. No logic changes.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `config`, `agent`

## Change Metadata

- Change type: `refactor`
- Primary scope: `config`

## Linked Issue

- Closes #66 (complementary to PR #76 which has the research findings)

## Why AgentConfig

`AgentConfig` already groups per-agent behavioral settings:

```toml
[agent]
compact_context = false
parallel_tools = true
max_tool_iterations = 20
tool_allowlist = ["shell", "file_read", "linear"]  # ← fits here
```

Previously `tool_allowlist` sat at the root level, making it easy to miss and harder to reason about. All 6 bot configs already had `[agent]` sections — the move is one line per config.

Additionally, this positions the field correctly for a future upstream contribution to `zeroclaw-labs/zeroclaw`. See `docs/planning/upstream-proposals.md` for the pathway.

## Files Changed

| File | Change |
|------|--------|
| `src/config/schema.rs` | Field removed from `Config`, added to `AgentConfig` + Default |
| `src/agent/agent.rs` | `config.tool_allowlist` → `config.agent.tool_allowlist` |
| `src/onboard/wizard.rs` | Remove 2 stale `tool_allowlist: Vec::new()` in Config literals |
| `config/*.example.toml` (6 files) | Move `tool_allowlist` from root into `[agent]` section |
| `docs/planning/upstream-proposals.md` | New: upstream contribution tracking + how-to guide |

## Validation Evidence (required)

```
cargo test --lib
test result: ok. 4039 passed; 0 failed; 4 ignored
```

Clippy errors present are all pre-existing upstream issues, not introduced by this change.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

**Note**: Removing `Config.tool_allowlist` without updating live configs would silently expose all tools (serde ignores unknown fields). Live gitignored configs updated locally alongside this PR.

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass

## Compatibility / Migration

- Backward compatible? **No** — breaking config change for any existing `config.toml` that uses root-level `tool_allowlist`
- Config/env changes? Yes
- Migration needed? Yes — move `tool_allowlist = [...]` from root into `[agent]` section

**Migration** (one-line change per config file):
```toml
# Before
tool_allowlist = ["shell", "file_read"]

[agent]
compact_context = false

# After
[agent]
compact_context = false
tool_allowlist = ["shell", "file_read"]
```

## i18n Follow-Through

- i18n follow-through triggered? No (no user-facing docs changed)

## Side Effects / Blast Radius (required)

- If an existing config still has root-level `tool_allowlist` after this change, the allowlist will be silently ignored and the bot will run with all tools exposed
- All 6 live bot configs (gitignored) updated locally

## Rollback Plan (required)

- Revert commit `ece6c212`
- Restore `tool_allowlist` to root of all live configs